### PR TITLE
fix: dispose Process in PowerPlans.cs after use

### DIFF
--- a/Universal x86 Tuning Utility Handheld/Scripts/Misc/PowerPlans.cs
+++ b/Universal x86 Tuning Utility Handheld/Scripts/Misc/PowerPlans.cs
@@ -15,15 +15,15 @@ namespace Universal_x86_Tuning_Utility.Scripts.Misc
             {
                 // Execute the "powercfg -attributes" command to hide the attribute
                 var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
                     {
-                        StartInfo = new ProcessStartInfo
-                        {
-                            FileName = "powercfg",
-                            Arguments = $"-attributes {subGroup} {attribute} -ATTRIB_HIDE",
-                            UseShellExecute = false,
-                            CreateNoWindow = true,
-                        }
-                    };
+                        FileName = "powercfg",
+                        Arguments = $"-attributes {subGroup} {attribute} -ATTRIB_HIDE",
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                    }
+                };
                 try
                 {
                     process.Start();

--- a/Universal x86 Tuning Utility Handheld/Scripts/Misc/PowerPlans.cs
+++ b/Universal x86 Tuning Utility Handheld/Scripts/Misc/PowerPlans.cs
@@ -15,17 +15,24 @@ namespace Universal_x86_Tuning_Utility.Scripts.Misc
             {
                 // Execute the "powercfg -attributes" command to hide the attribute
                 var process = new Process
-                {
-                    StartInfo = new ProcessStartInfo
                     {
-                        FileName = "powercfg",
-                        Arguments = $"-attributes {subGroup} {attribute} -ATTRIB_HIDE",
-                        UseShellExecute = false,
-                        CreateNoWindow = true,
-                    }
-                };
-                process.Start();
-                process.WaitForExit();
+                        StartInfo = new ProcessStartInfo
+                        {
+                            FileName = "powercfg",
+                            Arguments = $"-attributes {subGroup} {attribute} -ATTRIB_HIDE",
+                            UseShellExecute = false,
+                            CreateNoWindow = true,
+                        }
+                    };
+                try
+                {
+                    process.Start();
+                    process.WaitForExit();
+                }
+                finally
+                {
+                    process.Dispose();
+                }
             });
         }
         public async static void SetPowerValue(string scheme, string subGroup, string powerSetting, uint value, bool isAC)
@@ -43,8 +50,15 @@ namespace Universal_x86_Tuning_Utility.Scripts.Misc
                         CreateNoWindow = true,
                     }
                 };
-                process.Start();
-                process.WaitForExit();
+                try
+                {
+                    process.Start();
+                    process.WaitForExit();
+                }
+                finally
+                {
+                    process.Dispose();
+                }
             });
         }
 
@@ -63,8 +77,15 @@ namespace Universal_x86_Tuning_Utility.Scripts.Misc
                         CreateNoWindow = true,
                     }
                 };
-                process.Start();
-                process.WaitForExit();
+                try
+                {
+                    process.Start();
+                    process.WaitForExit();
+                }
+                finally
+                {
+                    process.Dispose();
+                }
             });
         }
     }


### PR DESCRIPTION
This change prevents handle leak, which eventually leads to memory exhaustion on the host system that can't be fixed without reboot.

Fixes #3 

Ref: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process?view=net-7.0#remarks
Ref: https://randomascii.wordpress.com/2018/02/11/zombie-processes-are-eating-your-memory/